### PR TITLE
Hide java implementation types from library users

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Usage
 
 ``` scala
   import play.modules.mailer._
-  import javax.mail.Message
 
   Mailer.sendEmail(Email(
     subject = "Test mail",

--- a/app/play/modules/mailer/Mailer.scala
+++ b/app/play/modules/mailer/Mailer.scala
@@ -5,7 +5,6 @@ import java.util.Date
 import java.util.Properties
 
 import javax.activation.DataHandler
-import javax.activation.DataSource
 import javax.mail.Authenticator
 import javax.mail.Message
 import javax.mail.Part
@@ -154,7 +153,7 @@ case class Email(subject: String, from: EmailAddress, replyTo: Option[EmailAddre
 }
 
 case class EmailAddress(name: String, address: String)
-case class Recipient(tpe: Message.RecipientType, emailAddress: EmailAddress)
+case class Recipient(tpe: RecipientType, emailAddress: EmailAddress)
 case class Attachment(name: String, datasource: DataSource, disposition: Disposition)
 
 abstract sealed class Disposition(val value: String)

--- a/app/play/modules/mailer/package.scala
+++ b/app/play/modules/mailer/package.scala
@@ -1,5 +1,11 @@
 package play.modules
 
 package object mailer {
-
+  type DataSource = javax.activation.DataSource
+  type RecipientType = javax.mail.Message.RecipientType
+  object RecipientType {
+    val TO:RecipientType=javax.mail.Message.RecipientType.TO
+    val BCC:RecipientType=javax.mail.Message.RecipientType.BCC
+    val CC:RecipientType=javax.mail.Message.RecipientType.CC
+  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import play._
 object ApplicationBuild extends Build {
 
   val appName = "play-mailer"
-  val appVersion = "1.1.1-SNAPSHOT"
+  val appVersion = "1.1.2-SNAPSHOT"
 
   val compileDependencies = Seq("javax.mail" % "mail" % "1.4")
   val testDependencies = Seq("org.jvnet.mock-javamail" % "mock-javamail" % "1.9" % "test")

--- a/test/play/modules/mailer/AsyncMailerSpec.scala
+++ b/test/play/modules/mailer/AsyncMailerSpec.scala
@@ -31,7 +31,7 @@ class AsyncMailerSpec extends Specification with BeforeAfter {
       subject = "Test mail",
       from = EmailAddress("Erik Westrb sender", "ewestrb@rhinofly.nl"),
       replyTo = None,
-      recipients = List(Recipient(Message.RecipientType.TO, EmailAddress("Erik Westrb recipient", "ewestrb@rhinofly.nl"))),
+      recipients = List(Recipient(RecipientType.TO, EmailAddress("Erik Westrb recipient", "ewestrb@rhinofly.nl"))),
       text = "text",
       htmlText = "htmlText",
       attachments = Seq.empty)).map(_=>inbox),Duration(1,"s"))

--- a/test/play/modules/mailer/MailerSpec.scala
+++ b/test/play/modules/mailer/MailerSpec.scala
@@ -28,7 +28,7 @@ class MailerSpec extends Specification with BeforeAfter {
       subject = "Test mail",
       from = EmailAddress("Erik Westra sender", "ewestra@rhinofly.nl"),
       replyTo = None,
-      recipients = List(Recipient(Message.RecipientType.TO, EmailAddress("Erik Westra recipient", "ewestra@rhinofly.nl"))),
+      recipients = List(Recipient(RecipientType.TO, EmailAddress("Erik Westra recipient", "ewestra@rhinofly.nl"))),
       text = "text",
       htmlText = "htmlText",
       attachments = Seq.empty))


### PR DESCRIPTION
This is a trick I have learned from https://speakerdeck.com/agemooij/from-a-to-l-designing-scala-libraries 

It allows you to hide type dependencies which are implementation details and allows to remove the javax import from production code while still being compatible with javax types if they are already used by the client code.
