### PR TITLE
Use UTF-8 encoding on email subject

### DIFF
--- a/app/play/modules/mailer/Mailer.scala
+++ b/app/play/modules/mailer/Mailer.scala
@@ -102,7 +102,7 @@ case class Email(subject: String, from: EmailAddress, replyTo: Option[EmailAddre
     val (root, related, alternative) = messageStructure
 
     val message = new MimeMessage(session)
-    message setSubject subject
+    message.setSubject(subject, "UTF-8")
     message setFrom from
     replyTo foreach (replyTo => message setReplyTo Array(replyTo))
     message setContent root


### PR DESCRIPTION
Email content (text & html) are set to UTF-8 by default but email subject is not. This change should set subject to UTF-8 by default.

Note: I haven't tested the code. Just edited on github since it's a small change.
